### PR TITLE
Trim whitespace from URL title

### DIFF
--- a/lib/paste-url.js
+++ b/lib/paste-url.js
@@ -43,7 +43,7 @@ function pasteURL() {
     fetch(url).then(res=>res.text()).then(text => {
       console.log("paste-url fetching: "+url)
       var newdom = new DOMParser().parseFromString(text, 'text/html');
-      const title = newdom.head.getElementsByTagName('title')[0].text;
+      const title = newdom.head.getElementsByTagName('title')[0].text.trim();
 
       // paste the URL with title into the Note
       const editor = global.inkdrop.getActiveEditor();


### PR DESCRIPTION
Leading and trailing whitespace inside a `<title>` tag is currently preserved. This results in a page containing the following HTML:

```html
<title>
    This is my page title
</title>
```

being output in Inkdrop as:

```markdown
[
    This is my page title
](...)
```

This change trims leading and trailing whitespace around a document title, so the outputted markdown would be as follows:

```markdown
[This is my page title](...)
```